### PR TITLE
Add Vagrantfile for Ubuntu VM for easy flashing of ESP8266

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 config.lua
+
+.vagrant/
+*.log

--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ Lua code to convert a toy traffic light into a extreme feedback device
 ```bash
     ./upload.sh
 ```
+## Preconfigured Ubuntu VM
+
+1. To mitigate driver issues and platform hassle, just install [VirtualBox|https://www.virtualbox.org/] and [Vagrant|https://www.vagrantup.com/]. 
+2. Call ```vagrant up && vagrant reload``` from the repository root.
+4. Call ```vagrant ssh``` to access the VM. 
+5. Continue with chapter 'Firmware for nodemcu' as all reguired dependencies have already been installed. Repository root is available as shared folder ```/vagrant```, changes are immediately propagated to the host.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Lua code to convert a toy traffic light into a extreme feedback device
 ```
 ## Preconfigured Ubuntu VM
 
-1. To mitigate driver issues and platform hassle, just install [VirtualBox|https://www.virtualbox.org/] and [Vagrant|https://www.vagrantup.com/]. 
+1. To mitigate driver issues and platform hassle, just install [VirtualBox](https://www.virtualbox.org/) and [Vagrant](https://www.vagrantup.com/). 
 2. Call ```vagrant up && vagrant reload``` from the repository root.
 4. Call ```vagrant ssh``` to access the VM. 
 5. Continue with chapter 'Firmware for nodemcu' as all reguired dependencies have already been installed. Repository root is available as shared folder ```/vagrant```, changes are immediately propagated to the host.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,24 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install -y linux-image-extra-virtual  
+    sudo apt-get install -y python-pip
+    pip install esptool
+    pip install nodemcu-uploader
+    echo "cd /vagrant" >> ~/.bashrc
+  SHELL
+
+  config.vm.provider "virtualbox" do |vb|
+  vb.customize ["modifyvm", :id, "--usb", "on"]
+  vb.customize ["modifyvm", :id, "--usbehci", "on"]
+  vb.customize ["usbfilter", "add", "0",
+    "--target", :id,
+    "--name", "ESP8266",
+    "--vendorid", "0x10c4",
+    "--productid", "0xea60"]
+  end
+end


### PR DESCRIPTION
As I was unable to get esptool.py to work on macOS Sierra 10.12.6, I opted to use a Ubuntu VM to do it without any hassle. Maybe my Vagrantfile is useful for other also.